### PR TITLE
Add flag to suppress error when there are no files to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can pass options to `metalsmith-in-place` with the [Javascript API](https://
 
 * [pattern](#pattern): optional. Only files that match this pattern will be processed. Accepts a string or an array of strings. The default is `**`.
 * [engineOptions](#engineoptions): optional. Use this to pass options to the jstransformer that's rendering your files. The default is `{}`.
+* [suppressNoFilesError](#suppressNoFilesError): optional. An error won’t be thrown if no files are present for processing. 
 
 ### `pattern`
 
@@ -64,6 +65,12 @@ Use this to pass options to the jstransformer that's rendering your templates. S
 ```
 
 Would pass `{ "cache": false }` to each used jstransformer.
+
+### `suppressNoFilesError`
+
+`metalsmith-in-place` throws [an error](#no-files-to-process) in metalsmith if it can’t find any files to process. [More info](https://github.com/metalsmith/metalsmith-in-place/pull/151). If you’re doing any kind of incremental builds via something like `metalsmith-watch`, this is problematic as you’re likely only rebuilding files that have changed. This flag allows you to suppress that error.
+
+Note that if you have [debugging](#errors-and-debugging) turned on, you’ll see a message denoting when no files are present for processing.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Would pass `{ "cache": false }` to each used jstransformer.
 
 ### `suppressNoFilesError`
 
-`metalsmith-in-place` throws [an error](#no-files-to-process) in metalsmith if it can’t find any files to process. [More info](https://github.com/metalsmith/metalsmith-in-place/pull/151). If you’re doing any kind of incremental builds via something like `metalsmith-watch`, this is problematic as you’re likely only rebuilding files that have changed. This flag allows you to suppress that error.
+`metalsmith-in-place` throws [an error](#no-files-to-process) in metalsmith if it can’t find any files to process. If you’re doing any kind of incremental builds via something like `metalsmith-watch`, this is problematic as you’re likely only rebuilding files that have changed. This flag allows you to suppress that error ([more info](https://github.com/metalsmith/metalsmith-in-place/pull/151)).
 
 Note that if you have [debugging](#errors-and-debugging) turned on, you’ll see a message denoting when no files are present for processing.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -129,11 +129,8 @@ module.exports = options => (files, metalsmith, done) => {
 
   // Let the user know when there are no files to process, usually caused by missing jstransformer
   if (validFiles.length === 0) {
-    done(
-      new Error(
-        'no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process'
-      )
-    );
+    debug('no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process');
+    done();
   }
 
   // Map all files that should be processed to an array of promises and call done when finished

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,7 +130,8 @@ module.exports = options => (files, metalsmith, done) => {
 
   // Let the user know when there are no files to process, usually caused by missing jstransformer
   if (validFiles.length === 0) {
-    const msg = 'no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process';
+    const msg =
+      'no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process';
     if (settings.suppressNoFilesError) {
       debug(msg);
       done();

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,8 @@ function validate({ filename, files }) {
 module.exports = options => (files, metalsmith, done) => {
   const defaults = {
     pattern: '**',
-    engineOptions: {}
+    engineOptions: {},
+    suppressNoFilesError: false
   };
   const settings = Object.assign({}, defaults, options);
   const metadata = metalsmith.metadata();
@@ -129,8 +130,13 @@ module.exports = options => (files, metalsmith, done) => {
 
   // Let the user know when there are no files to process, usually caused by missing jstransformer
   if (validFiles.length === 0) {
-    debug('no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process');
-    done();
+    const msg = 'no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process';
+    if (settings.suppressNoFilesError) {
+      debug(msg);
+      done();
+    } else {
+      done(new Error(msg));
+    }
   }
 
   // Map all files that should be processed to an array of promises and call done when finished

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -98,6 +98,16 @@ describe('metalsmith-in-place', () => {
     });
   });
 
+  it('should suppress the no files error when flag is set', done => {
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'no-files');
+    const metalsmith = new Metalsmith(base);
+
+    return metalsmith.use(plugin({ suppressNoFilesError: true })).build(err => {
+      expect(err).toBe(null);
+      done();
+    });
+  });
+
   it('should return an error for an invalid pattern', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'invalid-pattern');
     const metalsmith = new Metalsmith(base);


### PR DESCRIPTION
This is a problem for me in combination with [`metalsmith-watch`](https://github.com/FWeinb/metalsmith-watch).

The reason is because `metalsmith-watch` is watching for file changes, and if one of the files in my pipeline changes that doesn't need to be rendered by `metalsmith-in-place`, `metalsmith-in-place` is still stopping the whole show with an error, so none of my other file updates get rebuilt.

The proposal here is to not throw an error if there are no files to render. Just consider the process `done()`. If there *are* no files to change, we can log that out via the debug.

This should make `metalsmith-in-place` support partial rebuilds (instead of only full rebuilds).