### PR TITLE
(fix) add filename when jstransformer throws synchronously

### DIFF
--- a/lib/__snapshots__/index.test.js.snap
+++ b/lib/__snapshots__/index.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`metalsmith-in-place should prefix rendering errors with the filename 1`] = `"index.hbs: Something went wrong while rendering"`;
 
+exports[`metalsmith-in-place should prefix rendering errors with the filename when error is thrown synchronously 1`] = `"index.hbs: Something went wrong while rendering"`;
+
 exports[`metalsmith-in-place should return an error for an invalid pattern 1`] = `"invalid pattern, the pattern option should be a string or array of strings. See https://www.npmjs.com/package/metalsmith-in-place#pattern"`;
 
 exports[`metalsmith-in-place should return an error when there are no valid files to process 1`] = `"no files to process. See https://www.npmjs.com/package/metalsmith-in-place#no-files-to-process"`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,31 +45,36 @@ function render({ filename, files, metalsmith, settings }) {
   // Transform the contents
   debug(`rendering ${ext} extension for ${filename}`);
 
-  return transform
-    .renderAsync(contents, engineOptions, locals)
-    .then(rendered => {
-      // Delete old file
-      delete files[filename]; // eslint-disable-line no-param-reassign
+  try {
+    return transform
+      .renderAsync(contents, engineOptions, locals)
+      .then(rendered => {
+        // Delete old file
+        delete files[filename]; // eslint-disable-line no-param-reassign
 
-      // Update files with the newly rendered file
-      const newName = [base, ...extensions].join('.');
-      files[newName] = file; // eslint-disable-line no-param-reassign
-      files[newName].contents = Buffer.from(rendered.body); // eslint-disable-line no-param-reassign
+        // Update files with the newly rendered file
+        const newName = [base, ...extensions].join('.');
+        files[newName] = file; // eslint-disable-line no-param-reassign
+        files[newName].contents = Buffer.from(rendered.body); // eslint-disable-line no-param-reassign
 
-      debug(`done rendering ${filename}, renamed to ${newName}`);
+        debug(`done rendering ${filename}, renamed to ${newName}`);
 
-      // Stop rendering if this was the last extension
-      if (isLastExtension) {
-        return Promise.resolve();
-      }
+        // Stop rendering if this was the last extension
+        if (isLastExtension) {
+          return Promise.resolve();
+        }
 
-      // Otherwise, keep rendering until there are no applicable transformers left
-      return render({ filename: newName, files, metalsmith, settings });
-    })
-    .catch(err => {
-      err.message = `${filename}: ${err.message}`; // eslint-disable-line no-param-reassign
-      throw err;
-    });
+        // Otherwise, keep rendering until there are no applicable transformers left
+        return render({ filename: newName, files, metalsmith, settings });
+      })
+      .catch(err => {
+        err.message = `${filename}: ${err.message}`; // eslint-disable-line no-param-reassign
+        throw err;
+      });
+  } catch (err) {
+    err.message = `${filename}: ${err.message}`; // eslint-disable-line no-param-reassign
+    throw err;
+  }
 }
 
 /**

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -269,6 +269,26 @@ describe('metalsmith-in-place', () => {
     });
   });
 
+  it('should prefix rendering errors with the filename when error is thrown synchronously', done => {
+    jest.doMock('./get-transformer', () =>
+      jest.fn(() => ({
+        renderAsync: () => {
+          throw new Error('Something went wrong while rendering');
+        }
+      }))
+    );
+    const plugin = require('./index'); // eslint-disable-line global-require, no-shadow
+
+    const base = path.join(process.cwd(), 'test', 'fixtures', 'rendering-error');
+    const metalsmith = new Metalsmith(base);
+
+    return metalsmith.use(plugin()).build(err => {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toMatchSnapshot();
+      done();
+    });
+  });
+
   it('should accept an option to set the filename in engine options', done => {
     const base = path.join(process.cwd(), 'test', 'fixtures', 'set-filename');
     const actual = path.join(base, 'build');


### PR DESCRIPTION
Although renderAsync is used, it can throw synchronously.

If that happens, the error will not have a filename prefix.

(This might actually be a jstransformer issue, but I think it's best to fix it locally here since a change to jstransformer might take a take time)

